### PR TITLE
Add database replica source to `Database/Data`

### DIFF
--- a/docs/topics/Data.md
+++ b/docs/topics/Data.md
@@ -7,16 +7,16 @@ The o!TR team maintains a publicly accessible archive of database replicas to su
 
 ## Public Replicas
 
-Database replicas are updated weekly and stored in a Google Cloud storage bucket. **The public may browse available replicas [here](https://data.otr.stagec.xyz/).**
+Database replicas are updated every Wednesday at 00:00 UTC and are stored in a Google Cloud storage bucket. **The public may browse available replicas [here](https://data.otr.stagec.xyz/).**
 
 These public replicas omit the following information due to security and user privacy concerns:
 
 1. Admin notes
-2. Audit logs
-3. Logs
+2. Audit logs (tracks the state of entities over time)
+3. Logs (general purpose logs)
 4. OAuth clients
-5. User friends
-6. Users
+5. User friends (who an osu! user is following)
+6. Users (of the o!TR platform)
 
 Refer to the [disaster recovery](Disaster-Recovery.md#restore-the-database) guide for instructions on importing a replica locally.
 

--- a/docs/topics/Data.md
+++ b/docs/topics/Data.md
@@ -11,12 +11,12 @@ Database replicas are updated weekly and stored in a Google Cloud storage bucket
 
 These public replicas omit the following information due to security and user privacy concerns:
 
-1. Logs
-2. OAuth clients
-3. Audit logs
-4. User friends
-5. Users
-6. Admin notes
+1. Admin notes
+2. Audit logs
+3. Logs
+4. OAuth clients
+5. User friends
+6. Users
 
 Refer to the [disaster recovery](Disaster-Recovery.md#restore-the-database) guide for instructions on importing a replica locally.
 

--- a/docs/topics/Data.md
+++ b/docs/topics/Data.md
@@ -1,5 +1,25 @@
 # Data
 
-If you are on the dev team, reach out to [Stage](https://osu.ppy.sh/users/8191845) for a dump. Otherwise, please wait for a public dump to be made available.
+The o!TR team maintains a publicly accessible archive of database replicas to support two key objectives:
 
-If you have a database dump, you can populate your database by following the [recovery instructions](Disaster-Recovery.md).
+1. Facilitating development and contributions to the official [o!TR repositories](https://github.com/osu-tournament-rating/).
+2. Ensuring interested parties can verify a tournament (which used o!TR to seed or filter registrants) did so in a legitimate manner.
+
+## Public Replicas
+
+Database replicas are updated weekly and stored in a Google Cloud storage bucket. **The public may browse available replicas [here](https://data.otr.stagec.xyz/).**
+
+These public replicas omit the following information due to security and user privacy concerns:
+
+1. Logs
+2. OAuth clients
+3. Audit logs
+4. User friends
+5. Users
+6. Admin notes
+
+Refer to the [disaster recovery](Disaster-Recovery.md#restore-the-database) guide for instructions on importing a replica locally.
+
+> By downloading a public replica, you agree to comply with our [terms of use](https://data.otr.stagec.xyz/).
+>
+{style="note"}

--- a/docs/topics/Data.md
+++ b/docs/topics/Data.md
@@ -3,7 +3,7 @@
 The o!TR team maintains a publicly accessible archive of database replicas to support two key objectives:
 
 1. Facilitating development and contributions to the official [o!TR repositories](https://github.com/osu-tournament-rating/).
-2. Ensuring interested parties can verify a tournament (which used o!TR to seed or filter registrants) did so in a legitimate manner.
+2. Ensuring that interested parties may verify a tournament using o!TR to seed or filter registrants did so legitimately.
 
 ## Public Replicas
 


### PR DESCRIPTION
- Adds public database replica source
- Explains the terms of use
- Links to the terms of use & public replicas page
- Documents which types of data are not shared publicly

