### PR TITLE
Add docs for client gen

### DIFF
--- a/docs/otr.tree
+++ b/docs/otr.tree
@@ -34,6 +34,9 @@
             <toc-element topic="DataWorkerService.md"/>
         </toc-element>
     </toc-element>
+    <toc-element topic="o-TR-API-Clients.md">
+        <toc-element topic="Regenerate-Deploy.md"/>
+    </toc-element>
     <toc-element topic="o-TR-Database.md">
         <toc-element topic="Database-Setup.md"/>
         <toc-element topic="Data.md"/>
@@ -49,8 +52,5 @@
     <toc-element topic="o-TR-Docs.md">
         <toc-element topic="Getting-Started.md"/>
         <toc-element topic="Contribution.md"/>
-    </toc-element>
-    <toc-element topic="o-TR-API-Clients.md">
-        <toc-element topic="Regenerate-Deploy.md"/>
     </toc-element>
 </instance-profile>

--- a/docs/otr.tree
+++ b/docs/otr.tree
@@ -43,14 +43,14 @@
         <toc-element topic="Migrations.md"/>
         <toc-element topic="Disaster-Recovery.md"/>
     </toc-element>
+    <toc-element topic="o-TR-Docs.md">
+        <toc-element topic="Getting-Started.md"/>
+        <toc-element topic="Contribution.md"/>
+    </toc-element>
     <toc-element topic="o-TR-Processor.md">
         <toc-element topic="Processor-Getting-Started.md"/>
     </toc-element>
     <toc-element topic="o-TR-Web.md">
         <toc-element topic="Web-Getting-Started.md"/>
-    </toc-element>
-    <toc-element topic="o-TR-Docs.md">
-        <toc-element topic="Getting-Started.md"/>
-        <toc-element topic="Contribution.md"/>
     </toc-element>
 </instance-profile>

--- a/docs/otr.tree
+++ b/docs/otr.tree
@@ -50,4 +50,7 @@
         <toc-element topic="Getting-Started.md"/>
         <toc-element topic="Contribution.md"/>
     </toc-element>
+    <toc-element topic="o-TR-API-Clients.md">
+        <toc-element topic="Regenerate-Deploy.md"/>
+    </toc-element>
 </instance-profile>

--- a/docs/topics/Build.md
+++ b/docs/topics/Build.md
@@ -1,0 +1,3 @@
+# Build
+
+Start typing here...

--- a/docs/topics/Build.md
+++ b/docs/topics/Build.md
@@ -1,3 +1,0 @@
-# Build
-
-Start typing here...

--- a/docs/topics/Regenerate-Deploy.md
+++ b/docs/topics/Regenerate-Deploy.md
@@ -1,16 +1,23 @@
 # Regenerate & Deploy
 
+> This is non-sensitive internal documentation meant for use by the [o!TR Team](Team.md).
+
 This document outlines the process for regenerating and deploying API clients for the o!TR API. Currently, deployments are handled manually.
 
 ## Prerequisites
 
-* A working [o!TR API](o-TR-API.md) instance running locally.
+* A working [](o-TR-API.md) instance running locally.
 * [npm](https://www.npmjs.com/)
 * [NSwag](https://github.com/RicoSuter/NSwag) (`npm install nswag -g` recommended)
 
 <procedure>
 <step>
-Launch the <a href="o-TR-API.md">o!TR API</a> (ensure <code>Development</code> environment is configured)
+Launch the <a href="o-TR-API.md"/>
+
+<tip>
+Ensure that <code>ASPNETCORE_ENVIRONMENT=Development</code> is configured to launch swagger.
+See the <a href="Development.md">setup documentation</a> for more information.
+</tip>
 </step>
 <step>
 From the Swagger UI, download the <code>swagger.json</code> file and replace the existing file in the root directory of the repository.

--- a/docs/topics/Regenerate-Deploy.md
+++ b/docs/topics/Regenerate-Deploy.md
@@ -37,5 +37,6 @@ Publish:
 npm login
 npm version patch
 npm publish
-git push
 ```
+
+After these steps, commit and push any changes to the `master` branch.

--- a/docs/topics/Regenerate-Deploy.md
+++ b/docs/topics/Regenerate-Deploy.md
@@ -1,0 +1,41 @@
+# Regenerate & Deploy
+
+This document outlines the process for regenerating and deploying API clients for the o!TR API. Currently, deployments are handled manually.
+
+## Prerequisites
+
+* A working [o!TR API](o-TR-API.md) instance running locally.
+* [npm](https://www.npmjs.com/)
+* [NSwag](https://github.com/RicoSuter/NSwag) (`npm install nswag -g` recommended)
+
+<procedure>
+<step>
+Launch the <a href="o-TR-API.md">o!TR API</a> (ensure <code>Development</code> environment is configured)
+</step>
+<step>
+From the Swagger UI, download the <code>swagger.json</code> file and replace the existing file in the root directory of the repository.
+</step>
+<step>
+In the root directory of the repository, run <code>nswag run</code>.
+</step>
+</procedure>
+
+## npm
+
+Run and build:
+
+```
+cd ./src/ts
+npm i
+npm run build
+npm run format
+```
+
+Publish:
+
+```
+npm login
+npm version patch
+npm publish
+git push
+```

--- a/docs/topics/o-TR-API-Clients.md
+++ b/docs/topics/o-TR-API-Clients.md
@@ -1,0 +1,14 @@
+# o!TR API Clients
+
+The o!TR team maintains auto-generated wrappers which enable connectivity to the [o!TR API](o-TR-API.md).
+These clients are hosted on GitHub [here](https://github.com/osu-tournament-rating/otr-api-clients).
+
+## Languages
+
+The following languages are supported:
+
+- TypeScript
+
+## Contents
+
+<toc depth="1"/>


### PR DESCRIPTION
Adds documentation for the `otr-api-clients` repository, how to regenerate clients, and how to publish new packages.