### PR TITLE
Remove Powershell command support

### DIFF
--- a/docs/Applications/Database/Disaster Recovery.md
+++ b/docs/Applications/Database/Disaster Recovery.md
@@ -17,26 +17,15 @@ Backups are done with `pg_dump` and restores are done with `psql` ([see here](ht
 
 Backup the database into a compressed archive.
 
-> [!Powershell]-
->
-> ```
-> docker exec [container] pg_dump `
-> -c `
-> -U postgres `
-> -d postgres | gzip > /my/dir/dump.gz
-> ```
-
-> [!Bash]-
->
-> ```
-> docker exec [container] pg_dump \
-> -c \
-> -U postgres \
-> -d postgres | gzip > /my/dir/dump.gz
-> ```
+ ```
+ docker exec [container] pg_dump \
+ -c \
+ -U postgres \
+ -d postgres | gzip > /my/dir/dump.gz
+ ```
 
 > [!warning]
-> gzip needs to be present in the host machine. Alternatively, Windows users can use the Bash command instructions if executing through the git-bash utility.
+> gzip needs to be present in the host machine. 
 
 #### Restore the database
 
@@ -47,73 +36,37 @@ Backup the database into a compressed archive.
 
 Remove the `public` schema:
 
-> [!Powershell]-
->
-> ```
-> docker exec `
-> -it [container] psql `
-> -U postgres `
-> -c "DROP SCHEMA public CASCADE;" `
-> -d postgres
-> ```
-
-> [!Bash]-
->
-> ```
-> docker exec \
-> -it [container] psql \
-> -U postgres \
-> -c "DROP SCHEMA public CASCADE;" \
-> -d postgres
-> ```
+ ```
+ docker exec \
+ -it [container] psql \
+ -U postgres \
+ -c "DROP SCHEMA public CASCADE;" \
+ -d postgres
+ ```
 
 Create the `public` schema:
 
-> [!Powershell]-
->
-> ```
-> docker exec `
-> -it [container] psql `
-> -U postgres `
-> -c "CREATE SCHEMA public;" `
-> -d postgres
-> ```
-
-> [!Bash]-
->
-> ```
-> docker exec \
-> -it [container] psql \
-> -U postgres \
-> -c "CREATE SCHEMA public;" \
-> -d postgres
-> ```
+ ```
+ docker exec \
+ -it [container] psql \
+ -U postgres \
+ -c "CREATE SCHEMA public;" \
+ -d postgres
+ ```
 
 ##### Overwrite the database
 
 Overwrite your database with the dump:
 
-> [!powershell]-
->
-> ```
->  gunzip `
-> -c /my/dir/dump.gz | docker exec `
-> -i [container] psql `
-> -U postgres `
-> -d postgres
-> ```
-
-> [!bash]-
->
-> ```
-> gunzip \
-> -c /my/dir/dump.gz | docker exec \
-> -i [container] psql \
-> -U postgres \
-> -d postgres
-> ```
+ ```
+ gunzip \
+ -c /my/dir/dump.gz | docker exec \
+ -i [container] psql \
+ -U postgres \
+ -d postgres
+ ```
 
 > [!warning]
-> gunzip needs to be present in the host machine. Alternatively, Powershell users can use the Bash command instructions if executing through the git-bash utility.
+> gunzip needs to be present in the host machine. 
 
 Your database should now contain all of the data from the dump file.

--- a/docs/Applications/Database/Migrations.md
+++ b/docs/Applications/Database/Migrations.md
@@ -17,23 +17,13 @@ Migrations must be created and tested when any of the following are modified:
 
 To create a new migration, run the following in the root directory of the repository.
 
-> [!Powershell]-
->
-> ```
-> dotnet ef migrations add [Entity_ChangesMade] `
-> --project Database `
-> --startup-project API `
-> --context OtrContext
-> ```
 
-> [!Bash]-
->
-> ```
-> dotnet ef migrations add [Entity_ChangesMade] \
-> --project Database \
-> --startup-project API \
-> --context OtrContext
-> ```
+ ```
+ dotnet ef migrations add [Entity_ChangesMade] \
+ --project Database \
+ --startup-project API \
+ --context OtrContext
+ ```
 
 > [!info]
 > `[Entity_ChangesMade]` should be replaced with the name of your migration. Migrations should use PascalCase with underscores separating the entity from the changes made. For example, `Player_ConvertIdToInteger` is a good name for a migration as it describes the change made at a glance.
@@ -48,45 +38,23 @@ To create a new migration, run the following in the root directory of the reposi
 
 If you need to undo a migration, run the following command to revert the most recent migration.
 
-> [!Powershell]-
->
-> ```
-> dotnet ef migrations remove `
-> --project Database `
-> --startup-project API `
-> --context OtrContext
-> ```
-
-> [!Bash]-
->
-> ```
-> dotnet ef migrations remove \
-> --project Database \
-> --startup-project API \
-> --context OtrContext
-> ```
+ ```
+ dotnet ef migrations remove \
+ --project Database \
+ --startup-project API \
+ --context OtrContext
+ ```
 
 ## Applying Migrations
 
 Run the following to apply any pending migrations to the database. In development, ensure the database appears as expected after applying migrations.
 
-> [!powershell]-
->
-> ```
-> dotnet ef database update `
-> --project Database `
-> --startup-project API `
-> --context OtrContext
-> ```
-
-> [!Bash]-
->
-> ```
-> dotnet ef database update \
-> --project Database \
-> --startup-project API \
-> --context OtrContext
-> ```
+ ```
+ dotnet ef database update \
+ --project Database \
+ --startup-project API \
+ --context OtrContext
+ ```
 
 ## Apply Migrations in Production
 
@@ -96,27 +64,14 @@ First, a migrations script is generated via the entity framework CLI. Then, the 
 
 To generate the migrations script, run the following in the root directory of the repository:
 
-> [!Powershell]-
->
-> ```
-> dotnet ef migrations script `
-> --idempotent `
-> --project Database `
-> --startup-project API `
-> --context OtrContext `
-> -o script.sql
-> ```
-
-> [!Bash]-
->
-> ```
-> dotnet ef migrations script \
-> --idempotent \
-> --project Database \
-> --startup-project API \
-> --context OtrContext \
-> -o script.sql
-> ```
+ ```
+ dotnet ef migrations script \
+ --idempotent \
+ --project Database \
+ --startup-project API \
+ --context OtrContext \
+ -o script.sql
+ ```
 
 > [!note]
 > The `idempotent` flag tells the script to only apply migrations which have not already been applied.
@@ -125,20 +80,9 @@ To generate the migrations script, run the following in the root directory of th
 
 Apply the migrations:
 
-> [!Powershell]-
->
-> ```
-> cat script.sql | docker exec `
-> -i [container] psql `
-> -U postgres `
-> -d postgres
-> ```
-
-> [!Bash]-
->
-> ```
-> cat script.sql | docker exec \
-> -i [container] psql \
-> -U postgres \
-> -d postgres
-> ```
+ ```
+ cat script.sql | docker exec \
+ -i [container] psql \
+ -U postgres \
+ -d postgres
+ ```

--- a/docs/Applications/Database/Setup.md
+++ b/docs/Applications/Database/Setup.md
@@ -14,25 +14,13 @@ docker volume create otr-db
 
 Then, start the database:
 
-> [!Powershell]-
->
-> ```
-> docker run `
-> -d `
-> -p 5432:5432 `
-> -v otr-db:/var/lib/postgresql/data `
-> -e POSTGRES_PASSWORD=password postgres
-> ```
-
-> [!Bash]-
->
-> ```
-> docker run \
-> -d \
-> -p 5432:5432 \
-> -v otr-db:/var/lib/postgresql/data \
-> -e POSTGRES_PASSWORD=password postgres
-> ```
+ ```
+ docker run \
+ -d \
+ -p 5432:5432 \
+ -v otr-db:/var/lib/postgresql/data \
+ -e POSTGRES_PASSWORD=password postgres
+ ```
 
 ## Connection
 


### PR DESCRIPTION
removes all the OS-related collapsible menus for code blocks. Leaves just the Bash/macOS compatible commands as the only choice.