### PR TITLE
Add `Steps to Generate Ratings`, update disaster recovery docs

### DIFF
--- a/docs/Applications/Database/Disaster Recovery.md
+++ b/docs/Applications/Database/Disaster Recovery.md
@@ -7,60 +7,55 @@ This article explains how o!TR manages database backups and details a database d
 
 ## Production Backups
 
-Production backups are automated via a script set to run every six hours. The backups are compressed and uploaded to a Google Cloud storage bucket. At this time, only [Stage](https://osu.ppy.sh/users/8191845) can perform production recovery operations.
+Production backups are automated via a script set to run every six hours. The backups are compressed and uploaded to a Google Cloud Storage bucket. These scripts are part of an internal repository.
 
-### Backup Instructions
-
-Backups are done with `pg_dump` and restores are done with `psql` ([see here](https://www.postgresql.org/docs/current/backup-dump.html#BACKUP-DUMP)).
-
-#### Backup the database
-
-Backup the database into a compressed archive.
-
- ```
- docker exec [container] pg_dump \
- -c \
- -U postgres \
- -d postgres | gzip > /my/dir/dump.gz
- ```
-
-#### Restore the database
+## Restore the database
 
 > [!danger]
 > These steps will delete and overwrite your entire database.
 
-##### Clean the database
+>[!note]- Internal disaster recovery process
+>
+>##### Using the disaster recovery script
+>
+>For environments with the o!TR scripts repository set up, use the automated disaster recovery script:
+>
+> ```bash
+># This script will automatically:
+># - Download the latest dump from Google Cloud Storage
+># - Drop and recreate the database
+># - Import the dump
+># - Clean up temporary files
+># From the otr-scripts directory:
+> ./src/db/disaster-recovery.sh
+> ```
 
-Remove the `public` schema:
+### Manual restoration
 
- ```
- docker exec \
- -it [container] psql \
- -U postgres \
- -c "DROP SCHEMA public CASCADE;" \
- -d postgres
- ```
+>[!tip]
+>It is safe to ignore any errors displayed in the console during the import process.
 
-Create the `public` schema:
+If you have a database dump file and need to restore manually:
 
- ```
- docker exec \
- -it [container] psql \
- -U postgres \
- -c "CREATE SCHEMA public;" \
- -d postgres
- ```
+#### One-line import (recommended)
 
-##### Overwrite the database
+Drop, recreate, and import the database in a single command:
 
-Overwrite your database with the dump:
+```bash
+gunzip -c /path/to/dump.gz | docker exec -i [container] bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
+```
 
- ```
- gunzip \
- -c /my/dir/dump.gz | docker exec \
- -i [container] psql \
- -U postgres \
- -d postgres
- ```
+#### Step-by-step import
+
+Alternatively, you can perform the restoration in separate steps:
+
+```bash
+# Drop the existing database (if it exists) and create a new one
+docker exec -i [container] dropdb -f --if-exists -U postgres postgres
+docker exec -i [container] createdb -U postgres postgres
+
+# Import the compressed dump
+gunzip -c /path/to/dump.gz | docker exec -i [container] psql -U postgres -d postgres
+```
 
 Your database should now contain all of the data from the dump file.

--- a/docs/Applications/Database/Disaster Recovery.md
+++ b/docs/Applications/Database/Disaster Recovery.md
@@ -3,7 +3,7 @@ tags:
   - internal
 ---
 
-This article explains how o!TR manages database backups and details a database disaster recovery plan.
+This article explains how we manage database backups and details a database disaster recovery plan.
 
 ## Production Backups
 
@@ -11,29 +11,29 @@ Production backups are automated via a script set to run every six hours. The ba
 
 ## Restore the database
 
-> [!danger]
-> These steps will delete and overwrite your entire database.
-
->[!note]- Internal disaster recovery process
+> [!note]- Internal disaster recovery process
 >
->##### Using the disaster recovery script
+> ### Using the disaster recovery script
 >
->For environments with the o!TR scripts repository set up, use the automated disaster recovery script:
+> For environments with the o!TR scripts repository set up, use the automated disaster recovery script:
 >
 > ```bash
-># This script will automatically:
-># - Download the latest dump from Google Cloud Storage
-># - Drop and recreate the database
-># - Import the dump
-># - Clean up temporary files
-># From the otr-scripts directory:
+> # This script will automatically:
+> # - Download the latest dump from Google Cloud Storage
+> # - Drop and recreate the database
+> # - Import the dump
+> # - Clean up temporary files
+> # From the otr-scripts directory:
 > ./src/db/disaster-recovery.sh
 > ```
 
 ### Manual restoration
 
->[!tip]
->It is safe to ignore any errors displayed in the console during the import process.
+> [!danger]
+> These steps will delete and overwrite the entire database.
+
+> [!tip]
+> It is safe to ignore any errors displayed in the console during the import process.
 
 If you have a database dump file and need to restore manually:
 

--- a/docs/Steps to Generate Ratings.md
+++ b/docs/Steps to Generate Ratings.md
@@ -1,14 +1,14 @@
-This guide provides instructions for running the otr-processor locally to generate player ratings from publicly-available datasets. This enables independent verification of tournaments which use the platform for filtering and/or seeding.
+This guide provides instructions for running the [[Applications/Processor/Overview|otr-processor]] locally to generate player ratings from publicly-available datasets. This enables independent verification of tournaments which use our platform for filtering and/or seeding.
 
 > [!important]
-> The otr-processor version must be the most recent version released before the tournament's registration period. The processor uses date-based versioning in YYYY.MM.DD format. Different processor versions may produce different results due to algorithm updates.
+> The `otr-processor` version must be the most recent version released **before** the tournament's registration period. The processor uses date-based versioning in `YYYY.MM.DD` format. Different processor versions may produce different results due to algorithm updates.
 
 ## Prerequisites
 
 - [Docker](https://www.docker.com/get-started/)
 - (Windows only) [Git Bash](https://git-scm.com/downloads) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) - required because these commands use Unix-style syntax not supported by Windows Command Prompt or PowerShell.
 
-## Step 1: Set Up the Database
+## Step 1: Start the Database
 
 ```bash
 # Create database volume and container
@@ -23,24 +23,24 @@ docker run -d \
 
 ## Step 2: Import Database Dump
 
-Public database dumps are available at [https://data.otr.stagec.xyz](https://data.otr.stagec.xyz). These weekly replicas exclude most data, but provide enough data to verify a tournament's use of o!TR.
+Public database dumps are available [here](https://data.otr.stagec.xyz). These weekly replicas exclude most data, but provide enough data to verify a tournament's use of o!TR.
 
-Download the most recent dump dated before the tournament's registration period.
+Download the most recent dump dated before the tournament closed registrations. If the tournament provides another date by which ratings are taken from, use that date instead.
 
 ### Import the dump
 
-This command will drop, recreate, and import the database in a single operation:
+Use this command to overwrite your `otr-postgres` volume data.
 
 ```bash
 gunzip -c /path/to/replica.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
 ```
 
-> [!note]
-> Any errors during import can be safely ignored
+> [!tip]
+> Some errors, such as `ERROR: role [...] does not exist`, can be safely ignored.
 
 ## Step 3: Run the Processor
 
-Browse the [releases page](https://github.com/osu-tournament-rating/otr-processor/releases) to find the most recent processor version released before the day the tournament used o!TR to filter and/or seed participants. This is typically the day registrations end, though the tournament should specify clearly.
+Browse the [releases page](https://github.com/osu-tournament-rating/otr-processor/releases) to find a processor version to use. Then, take the name of the release and replace the `YYYY.MM.DD` text below with that value.
 
 ```bash
 docker run --rm \
@@ -51,17 +51,27 @@ docker run --rm \
   stagecodes/otr-processor:YYYY.MM.DD
 ```
 
-## Step 4: Export Player Ratings
-
-Export player ratings for verification. Replace `ruleset` values as follows: 0=osu!, 1=taiko, 2=catch, 4=mania 4K, 5=mania 7K.
+> [!example]
+> If the [[Applications/Processor/Overview|otr-processor]] version is `2025.06.19`, run using the `otr-processor:2025.06.19` image.
 
 > [!tip]
-> To validate the ratings of all players in a tournament from this point in time, import the csv files generated using the below steps into a spreadsheet. Then, use the spreadsheet software to filter against the list of osu! IDs
+> To run pre-production changes, use the `:staging` tag. To run the latest production version, use the `:latest` tag.
+
+## Step 4: Export Player Ratings
+
+Export player ratings for verification. Replace `ruleset` values as follows:
+
+- 0=osu!
+- 1=osu!taiko
+- 2=osu!catch
+- 3=osu!mania (Other) [No ratings are generated for this ruleset]
+- 4=osu!mania 4K
+- 5=osu!mania 7K
 
 ### Export Specific Game Mode (Recommended)
 
 ```bash
-# Export osu! standard ratings (ruleset = 0)
+# Export osu! ratings (ruleset = 0)
 docker exec -it otr-postgres psql -U postgres -d postgres -c "\
 COPY (
     SELECT
@@ -74,7 +84,7 @@ COPY (
     FROM public.players p
     JOIN public.player_ratings pr ON p.id = pr.player_id
     WHERE pr.ruleset = 0
---                    ^^^ == EDIT THIS VALUE ==
+--                    ^^^ == Edit ruleset here ==
     ORDER BY pr.rating DESC
 ) TO STDOUT WITH CSV HEADER;" > ratings_osu.csv
 ```
@@ -104,21 +114,16 @@ COPY (
 ) TO STDOUT WITH CSV HEADER;" > all_ratings.csv
 ```
 
+> [!tip]
+> Import this data into a spreadsheet for analysis.
+
 ## Step 5: Filter Ratings for Specific Players
 
 After exporting ratings to CSV files, you may want to filter them for specific players. This is useful when verifying ratings for tournament participants.
 
-### Method 1: Filter by Individual osu! IDs
+### Method 1: Filter Using a List File
 
-```bash
-# Filter for specific osu! IDs (replace 12345|67890 with actual IDs).
-# Note, the regex will partially match, meaning "^(11)" will include everyone whose ID starts with 11
-head -1 all_ratings.csv > filtered_ratings.csv && grep -E "^(12345|67890|11111)" all_ratings.csv >> filtered_ratings.csv
-```
-
-### Method 2: Filter Using a List File
-
-If you have many IDs, create a text file with one osu! ID per line:
+If you have many IDs, create a text file called `player_ids.txt` with one osu! ID per line:
 
 ```bash
 # Create a file with osu! IDs
@@ -126,6 +131,16 @@ echo -e "8191845\n11557554\n7823498" > player_ids.txt
 
 # Filter using the ID list
 head -1 all_ratings.csv > filtered_ratings.csv && grep -f player_ids.txt all_ratings.csv >> filtered_ratings.csv
+```
+
+### Method 2: Filter by Individual osu! IDs
+
+> [!warning]
+> This regex will partially match on any **row**, meaning `^(11)` will include every row containing `11`. If full osu! IDs are provided, accurate rows will be returned.
+
+```bash
+# Filter for specific osu! IDs (replace 12345|67890 with actual IDs).
+head -1 all_ratings.csv > filtered_ratings.csv && grep -E "^(12345|67890|11111)" all_ratings.csv >> filtered_ratings.csv
 ```
 
 ### Example Output
@@ -136,8 +151,6 @@ After filtering, your CSV will contain only the specified players:
 osu_id,username,country,ruleset,rating,volatility,percentile,global_rank,country_rank
 11557554,Cytusine,US,0,1471.6847685949424,221.60678571859532,96.70174677226863,608,107
 8191845,Stage,US,0,1116.3175053076163,276.7000024131878,82.53770207225777,3219,522
-11557554,Cytusine,US,1,963.0656128340958,297.23443168412547,54.097452934662236,829,63
-11557554,Cytusine,US,4,483.4417050410036,293.7349217649456,1.2587412587412588,2118,218
 ```
 
 ## Cleanup
@@ -152,5 +165,5 @@ docker volume rm otr-db
 ## Troubleshooting
 
 - **Database connection refused**: Ensure PostgreSQL container is running with `docker ps`
-- **Processor runs but crashes**: Ensure the `IGNORE_CONSTRAINTS=true` environment variable is set (using `-E`). If other unexpected issues occur, please [[contact|contact us]].
+- **Processor runs but crashes**: Ensure the `IGNORE_CONSTRAINTS=true` environment variable is set (using `-e`). If other unexpected issues occur, please [[contact|contact us]].
 - **Export produces empty files**: Verify the database import completed successfully

--- a/docs/Steps to Get Started.md
+++ b/docs/Steps to Get Started.md
@@ -5,7 +5,8 @@ This guide provides instructions for running the otr-processor locally to genera
 
 ## Prerequisites
 
-- Docker Desktop or Docker Engine
+- [Docker](https://www.docker.com/get-started/)
+- (Windows only) [Git Bash](https://git-scm.com/downloads) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) - required because these commands use Unix-style syntax not supported by Windows Command Prompt or PowerShell.
 
 ## Step 1: Set Up the Database
 
@@ -15,7 +16,7 @@ docker volume create otr-db
 docker run -d \
   --name otr-postgres \
   -p 5432:5432 \
-  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_PASSWORD=password \
   -v otr-db:/var/lib/postgresql/data \
   postgres:17
 ```
@@ -31,7 +32,7 @@ Download the most recent dump dated before the tournament's registration period.
 This command will drop, recreate, and import the database in a single operation:
 
 ```bash
-gunzip -c your-dump.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
+gunzip -c /path/to/replica.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
 ```
 
 > [!note]
@@ -42,12 +43,11 @@ gunzip -c your-dump.gz | docker exec -i otr-postgres bash -c "psql -U postgres -
 Browse the [releases page](https://github.com/osu-tournament-rating/otr-processor/releases) to find the most recent processor version released before the day the tournament used o!TR to filter and/or seed participants. This is typically the day registrations end, though the tournament should specify clearly.
 
 ```bash
-# Pull and run the processor (replace YYYY.MM.DD with the appropriate version)
-docker pull stagecodes/otr-processor:YYYY.MM.DD
 docker run --rm \
   --name otr-processor \
   --network host \
-  -e CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres" \
+  -e CONNECTION_STRING="postgresql://postgres:password@localhost:5432/postgres" \
+  -e IGNORE_CONSTRAINTS=true \
   stagecodes/otr-processor:YYYY.MM.DD
 ```
 
@@ -55,7 +55,34 @@ docker run --rm \
 
 Export player ratings for verification. Replace `ruleset` values as follows: 0=osu!, 1=taiko, 2=catch, 4=mania 4K, 5=mania 7K.
 
+> [!tip]
+> To validate the ratings of all players in a tournament from this point in time, import the csv files generated using the below steps into a spreadsheet. Then, use the spreadsheet software to filter against the list of osu! IDs
+
+### Export Specific Game Mode (Recommended)
+
+```bash
+# Export osu! standard ratings (ruleset = 0)
+docker exec -it otr-postgres psql -U postgres -d postgres -c "\
+COPY (
+    SELECT
+        p.osu_id,
+        p.username,
+        p.country,
+        pr.rating,
+        pr.global_rank,
+        pr.country_rank
+    FROM public.players p
+    JOIN public.player_ratings pr ON p.id = pr.player_id
+    WHERE pr.ruleset = 0
+--                    ^^^ == EDIT THIS VALUE ==
+    ORDER BY pr.rating DESC
+) TO STDOUT WITH CSV HEADER;" > ratings_osu.csv
+```
+
 ### Export All Ratings
+
+> [!warning]
+> Be aware that one player may have multiple ratings, one per ruleset.
 
 ```bash
 # Export all player ratings to CSV
@@ -73,29 +100,44 @@ COPY (
         pr.country_rank
     FROM public.players p
     JOIN public.player_ratings pr ON p.id = pr.player_id
-    WHERE pr.matches_played > 0
     ORDER BY pr.ruleset, pr.rating DESC
 ) TO STDOUT WITH CSV HEADER;" > all_ratings.csv
 ```
 
-### Export Specific Game Mode
+## Step 5: Filter Ratings for Specific Players
+
+After exporting ratings to CSV files, you may want to filter them for specific players. This is useful when verifying ratings for tournament participants.
+
+### Method 1: Filter by Individual osu! IDs
 
 ```bash
-# Export osu! standard ratings (ruleset = 0)
-docker exec -it otr-postgres psql -U postgres -d postgres -c "\
-COPY (
-    SELECT
-        p.osu_id,
-        p.username,
-        p.country,
-        pr.rating,
-        pr.global_rank,
-        pr.country_rank
-    FROM public.players p
-    JOIN public.player_ratings pr ON p.id = pr.player_id
-    WHERE pr.ruleset = 0 AND pr.matches_played > 0
-    ORDER BY pr.rating DESC
-) TO STDOUT WITH CSV HEADER;" > ratings_osu.csv
+# Filter for specific osu! IDs (replace 12345|67890 with actual IDs).
+# Note, the regex will partially match, meaning "^(11)" will include everyone whose ID starts with 11
+head -1 all_ratings.csv > filtered_ratings.csv && grep -E "^(12345|67890|11111)" all_ratings.csv >> filtered_ratings.csv
+```
+
+### Method 2: Filter Using a List File
+
+If you have many IDs, create a text file with one osu! ID per line:
+
+```bash
+# Create a file with osu! IDs
+echo -e "8191845\n11557554\n7823498" > player_ids.txt
+
+# Filter using the ID list
+head -1 all_ratings.csv > filtered_ratings.csv && grep -f player_ids.txt all_ratings.csv >> filtered_ratings.csv
+```
+
+### Example Output
+
+After filtering, your CSV will contain only the specified players:
+
+```csv
+osu_id,username,country,ruleset,rating,volatility,percentile,global_rank,country_rank
+11557554,Cytusine,US,0,1471.6847685949424,221.60678571859532,96.70174677226863,608,107
+8191845,Stage,US,0,1116.3175053076163,276.7000024131878,82.53770207225777,3219,522
+11557554,Cytusine,US,1,963.0656128340958,297.23443168412547,54.097452934662236,829,63
+11557554,Cytusine,US,4,483.4417050410036,293.7349217649456,1.2587412587412588,2118,218
 ```
 
 ## Cleanup
@@ -110,35 +152,5 @@ docker volume rm otr-db
 ## Troubleshooting
 
 - **Database connection refused**: Ensure PostgreSQL container is running with `docker ps`
-- **Processor runs but no ratings generated**: Check processor logs with `docker logs otr-processor`
+- **Processor runs but crashes**: Ensure the `IGNORE_CONSTRAINTS=true` environment variable is set (using `-E`). If other unexpected issues occur, please [[contact|contact us]].
 - **Export produces empty files**: Verify the database import completed successfully
-
-## Example: Tournament Verification
-
-Verifying ratings for a tournament with registrations closing March 1, 2024:
-
-```bash
-# 1. Set up database
-docker volume create otr-db
-docker run -d --name otr-postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -v otr-db:/var/lib/postgresql/data postgres:17
-
-# 2. Import database dump from https://data.otr.stagec.xyz (one-line command)
-gunzip -c your-dump.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
-
-# 4. Run processor (version from before March 1, 2024)
-docker pull stagecodes/otr-processor:YYYY.MM.DD
-docker run --rm --name otr-processor --network host -e CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres" stagecodes/otr-processor:YYYY.MM.DD
-
-# 5. Export ratings (ruleset: 0=osu!, 1=taiko, 2=catch, 3=mania)
-docker exec -it otr-postgres psql -U postgres -d postgres -c "\
-COPY (
-    SELECT p.osu_id, p.username, p.country, pr.rating, pr.global_rank
-    FROM public.players p
-    JOIN public.player_ratings pr ON p.id = pr.player_id
-    WHERE pr.ruleset = 0 AND pr.matches_played > 0
-    ORDER BY pr.rating DESC
-) TO STDOUT WITH CSV HEADER;" > tournament_verification.csv
-
-# 6. Cleanup
-docker stop otr-postgres && docker rm otr-postgres && docker volume rm otr-db
-```

--- a/docs/Steps to Get Started.md
+++ b/docs/Steps to Get Started.md
@@ -1,0 +1,144 @@
+This guide provides instructions for running the otr-processor locally to generate player ratings from publicly-available datasets. This enables independent verification of tournaments which use the platform for filtering and/or seeding.
+
+> [!important]
+> The otr-processor version must be the most recent version released before the tournament's registration period. The processor uses date-based versioning in YYYY.MM.DD format. Different processor versions may produce different results due to algorithm updates.
+
+## Prerequisites
+
+- Docker Desktop or Docker Engine
+
+## Step 1: Set Up the Database
+
+```bash
+# Create database volume and container
+docker volume create otr-db
+docker run -d \
+  --name otr-postgres \
+  -p 5432:5432 \
+  -e POSTGRES_PASSWORD=postgres \
+  -v otr-db:/var/lib/postgresql/data \
+  postgres:17
+```
+
+## Step 2: Import Database Dump
+
+Public database dumps are available at [https://data.otr.stagec.xyz](https://data.otr.stagec.xyz). These weekly replicas exclude most data, but provide enough data to verify a tournament's use of o!TR.
+
+Download the most recent dump dated before the tournament's registration period.
+
+### Import the dump
+
+This command will drop, recreate, and import the database in a single operation:
+
+```bash
+gunzip -c your-dump.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
+```
+
+> [!note]
+> Any errors during import can be safely ignored
+
+## Step 3: Run the Processor
+
+Browse the [releases page](https://github.com/osu-tournament-rating/otr-processor/releases) to find the most recent processor version released before the day the tournament used o!TR to filter and/or seed participants. This is typically the day registrations end, though the tournament should specify clearly.
+
+```bash
+# Pull and run the processor (replace YYYY.MM.DD with the appropriate version)
+docker pull stagecodes/otr-processor:YYYY.MM.DD
+docker run --rm \
+  --name otr-processor \
+  --network host \
+  -e CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres" \
+  stagecodes/otr-processor:YYYY.MM.DD
+```
+
+## Step 4: Export Player Ratings
+
+Export player ratings for verification. Replace `ruleset` values as follows: 0=osu!, 1=taiko, 2=catch, 4=mania 4K, 5=mania 7K.
+
+### Export All Ratings
+
+```bash
+# Export all player ratings to CSV
+docker exec -it otr-postgres psql -U postgres -d postgres -c "\
+COPY (
+    SELECT
+        p.osu_id,
+        p.username,
+        p.country,
+        pr.ruleset,
+        pr.rating,
+        pr.volatility,
+        pr.percentile,
+        pr.global_rank,
+        pr.country_rank
+    FROM public.players p
+    JOIN public.player_ratings pr ON p.id = pr.player_id
+    WHERE pr.matches_played > 0
+    ORDER BY pr.ruleset, pr.rating DESC
+) TO STDOUT WITH CSV HEADER;" > all_ratings.csv
+```
+
+### Export Specific Game Mode
+
+```bash
+# Export osu! standard ratings (ruleset = 0)
+docker exec -it otr-postgres psql -U postgres -d postgres -c "\
+COPY (
+    SELECT
+        p.osu_id,
+        p.username,
+        p.country,
+        pr.rating,
+        pr.global_rank,
+        pr.country_rank
+    FROM public.players p
+    JOIN public.player_ratings pr ON p.id = pr.player_id
+    WHERE pr.ruleset = 0 AND pr.matches_played > 0
+    ORDER BY pr.rating DESC
+) TO STDOUT WITH CSV HEADER;" > ratings_osu.csv
+```
+
+## Cleanup
+
+```bash
+# Stop and remove containers and volumes
+docker stop otr-postgres
+docker rm otr-postgres
+docker volume rm otr-db
+```
+
+## Troubleshooting
+
+- **Database connection refused**: Ensure PostgreSQL container is running with `docker ps`
+- **Processor runs but no ratings generated**: Check processor logs with `docker logs otr-processor`
+- **Export produces empty files**: Verify the database import completed successfully
+
+## Example: Tournament Verification
+
+Verifying ratings for a tournament with registrations closing March 1, 2024:
+
+```bash
+# 1. Set up database
+docker volume create otr-db
+docker run -d --name otr-postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -v otr-db:/var/lib/postgresql/data postgres:17
+
+# 2. Import database dump from https://data.otr.stagec.xyz (one-line command)
+gunzip -c your-dump.gz | docker exec -i otr-postgres bash -c "psql -U postgres -d template1 -c 'DROP DATABASE IF EXISTS postgres;' && psql -U postgres -d template1 -c 'CREATE DATABASE postgres;' && psql -U postgres -d postgres"
+
+# 4. Run processor (version from before March 1, 2024)
+docker pull stagecodes/otr-processor:YYYY.MM.DD
+docker run --rm --name otr-processor --network host -e CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres" stagecodes/otr-processor:YYYY.MM.DD
+
+# 5. Export ratings (ruleset: 0=osu!, 1=taiko, 2=catch, 3=mania)
+docker exec -it otr-postgres psql -U postgres -d postgres -c "\
+COPY (
+    SELECT p.osu_id, p.username, p.country, pr.rating, pr.global_rank
+    FROM public.players p
+    JOIN public.player_ratings pr ON p.id = pr.player_id
+    WHERE pr.ruleset = 0 AND pr.matches_played > 0
+    ORDER BY pr.rating DESC
+) TO STDOUT WITH CSV HEADER;" > tournament_verification.csv
+
+# 6. Cleanup
+docker stop otr-postgres && docker rm otr-postgres && docker volume rm otr-db
+```


### PR DESCRIPTION
Adds a "Steps to Generate Ratings" guide. This guides users through database setup & import, otr-processor execution, and how to export the data into CSV files. Some basic troubleshooting steps are added to aid users in the event of any issues. Article instructs users on how to filter for specific osu! IDs.

Disaster recovery steps now reflect our new database import process (staging/prod use the 'otr-scripts' repo for this). Developers/those following the steps to generate ratings article can now import their database in **one line**. The command automatically overwrites the existing database instance - no need to drop and recreate the public schema anymore.

Closes #54