### PR TITLE
Use `otr-db` for database container name

### DIFF
--- a/docs/Applications/Database/Setup.md
+++ b/docs/Applications/Database/Setup.md
@@ -17,6 +17,7 @@ Then, start the database:
  ```
  docker run \
  -d \
+ --name otr-db \
  -p 5432:5432 \
  -v otr-db:/var/lib/postgresql/data \
  -e POSTGRES_PASSWORD=password postgres

--- a/docs/Steps to Generate Ratings.md
+++ b/docs/Steps to Generate Ratings.md
@@ -14,7 +14,7 @@ This guide provides instructions for running the [[Applications/Processor/Overvi
 # Create database volume and container
 docker volume create otr-db
 docker run -d \
-  --name otr-postgres \
+  --name otr-db \
   -p 5432:5432 \
   -e POSTGRES_PASSWORD=password \
   -v otr-db:/var/lib/postgresql/data \


### PR DESCRIPTION
Updates some postgres container instructions to use `otr-db` as the container name. If a user sets up a container using one set of instructions, it should work in other parts of the doc that use the database.