### PR TITLE
Fix sign error in rating documentation

### DIFF
--- a/docs/Rating Framework/Rating Calculation/Initial Ratings.md
+++ b/docs/Rating Framework/Rating Calculation/Initial Ratings.md
@@ -20,7 +20,7 @@ $$
     \text{initial rating} =
         \begin{cases}
             1200 + 200 \cdot z_{\text{rank}}, & \text{if }z_{\text{rank}} \ge 0, \\
-            1200 - 250 \cdot z_{\text{rank}}, & \text{otherwise},
+            1200 + 250 \cdot z_{\text{rank}}, & \text{otherwise},
         \end{cases}
 \end{equation}
 $$


### PR DESCRIPTION
oops a very negative z-score does not mean you have a very high rating

(it's correct in the [actual code](https://github.com/osu-tournament-rating/otr-processor/blob/master/src/model/rating_utils.rs#L137), don't worry)