### PR TITLE
Enable manual deployment via workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Allow triggering the deploy workflow manually from the GitHub Actions UI without requiring a commit to master.