### PR TITLE
Lowercase environment name in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     name: Deploy
     runs-on: ubuntu-latest
-    environment: Production
+    environment: production
 
     steps:
       - name: Deploy


### PR DESCRIPTION
- Change `environment: Production` to `environment: production` in `deploy.yml`

The GitHub Environment named `Production` must be renamed to lowercase before this is merged.