### PR TITLE
Add `API/Changelog`

### DIFF
--- a/docs/API/Changelog.md
+++ b/docs/API/Changelog.md
@@ -1,4 +1,4 @@
-This page records changes to the public o!TR API
+This page records changes to the public [o!TR API](https://otr.stagec.net/spec)
 
 > [!warning]
 > The API is still evolving and is not considered stable. Breaking changes may ship without advance notice. Consumers should read this page alongside each [release](https://github.com/osu-tournament-rating/otr-web/releases).

--- a/docs/API/Changelog.md
+++ b/docs/API/Changelog.md
@@ -1,7 +1,7 @@
 This page records changes to the public [o!TR API](https://otr.stagec.net/spec)
 
 > [!warning]
-> The API is still evolving and is not considered stable. Breaking changes may ship without advance notice. Consumers should read this page alongside each [release](https://github.com/osu-tournament-rating/otr-web/releases).
+> The API is still evolving and is not considered stable. Breaking changes may be introduced without advance notice. Consumers should read this page alongside each [release](https://github.com/osu-tournament-rating/otr-web/releases).
 
 ## Unreleased
 

--- a/docs/API/Changelog.md
+++ b/docs/API/Changelog.md
@@ -1,0 +1,8 @@
+This page records changes to the public o!TR API
+
+> [!warning]
+> The API is still evolving and is not considered stable. Breaking changes may ship without advance notice. Consumers should read this page alongside each [release](https://github.com/osu-tournament-rating/otr-web/releases).
+
+## Unreleased
+
+- Removed `GET /beatmaps/{beatmapId}/tournaments/{tournamentId}/matches`


### PR DESCRIPTION
Adds `API/Changelog` to track breaking API changes. `## Unreleased` will be updated with the otr-web version once the release is created.